### PR TITLE
Changed method call from Time.current to Time.now

### DIFF
--- a/lib/simplecov-badge.rb
+++ b/lib/simplecov-badge.rb
@@ -122,7 +122,7 @@ class SimpleCov::Formatter::BadgeFormatter
       convert #{output_path}/coverage-badge.png -alpha set -bordercolor none -border 3 \
       -gravity North -chop 0x3 \
       -gravity East -chop 3x0 \
-      -gravity West -chop 3x0 \\( -background none -font 'Helvetica' label:'Generated #{Time.current.strftime('%m-%d-%y %H:%M UTC')}' \\) -background none -gravity center -append #{output_path}/coverage-badge.png
+      -gravity West -chop 3x0 \\( -background none -font 'Helvetica' label:'Generated #{Time.now.strftime('%m-%d-%y %H:%M UTC')}' \\) -background none -gravity center -append #{output_path}/coverage-badge.png
     """
     output = `#{timestamp_cmd}`
     check_status(output)

--- a/spec/simplecov-badge_spec.rb
+++ b/spec/simplecov-badge_spec.rb
@@ -22,6 +22,9 @@ describe SimpleCov::Formatter::BadgeFormatter do
       SimpleCov::Formatter::BadgeFormatter.generate_groups.should eq(true)
       SimpleCov::Formatter::BadgeFormatter.generate_groups = false
       SimpleCov::Formatter::BadgeFormatter.generate_groups.should eq(false)
+      SimpleCov::Formatter::BadgeFormatter.timestamp.should eq(false)
+      SimpleCov::Formatter::BadgeFormatter.timestamp = true
+      SimpleCov::Formatter::BadgeFormatter.timestamp.should eq(true)
     end
   end
   


### PR DESCRIPTION
`Time.current` appears to be Rails-specific and causes a `NoMethodError` to be raised when `SimpleCov::Formatter::BadgeFormatter.timestamp = true`. Changing the method call to `Time.now` fixes the issue.
