### PR TITLE
Fix imagemagick check on OS X (Fixes: #7)

### DIFF
--- a/lib/simplecov-badge.rb
+++ b/lib/simplecov-badge.rb
@@ -4,8 +4,8 @@ if Gem::Version.new(SimpleCov::VERSION) < Gem::Version.new("0.7.1")
 end
 
 ImageMagickError = Class.new(StandardError)
-  
-class SimpleCov::Formatter::BadgeFormatter  
+
+class SimpleCov::Formatter::BadgeFormatter
   # Set up config variables.
   options = {:badge_title => 'TEST COVERAGE', :generate_groups => true, :timestamp => false, :green => '#4fb151',
             :yellow => '#ded443', :red => '#a23e3f', :number_font => 'Helvetica-Narrow-Bold',
@@ -15,7 +15,7 @@ class SimpleCov::Formatter::BadgeFormatter
             :group_name_font => 'Helvetica-Bold', :group_name_font_size => 15,
             :group_badge_height => 22, :group_strength_foreground => false, :color_code_title => true,
             :group_color_code_title => true}
-    
+
   # set up class variables and getters/setters
   options.each do |opt,v|
     set = "@@#{opt} = v"
@@ -25,7 +25,7 @@ class SimpleCov::Formatter::BadgeFormatter
     eval(getter)
     eval(setter)
   end
-  
+
   def format(result)
     begin
       check_imagemagick
@@ -40,13 +40,13 @@ class SimpleCov::Formatter::BadgeFormatter
   end
 
   private
-  
+
   def generate_header_badge(result)
     overall_cov = result.source_files.covered_percent.round(0)
     overall_strength = result.covered_strength.round(0)
     generator(overall_cov, overall_strength, false)
   end
-  
+
   def generate_group_badges(result)
     result.groups.each do |name, files|
       cov = files.covered_percent.round(0)
@@ -54,7 +54,7 @@ class SimpleCov::Formatter::BadgeFormatter
       generator(cov, strength, name)
     end
   end
-  
+
   def generator(cov, strength, group)
     command = []
     command[0] = """
@@ -116,7 +116,7 @@ class SimpleCov::Formatter::BadgeFormatter
       system("rm #{output_path}/tmp.png")
     end
   end
-  
+
   def generate_timestamp
     timestamp_cmd = """
       convert #{output_path}/coverage-badge.png -alpha set -bordercolor none -border 3 \
@@ -127,7 +127,7 @@ class SimpleCov::Formatter::BadgeFormatter
     output = `#{timestamp_cmd}`
     check_status(output)
   end
-  
+
   # getter method for config variables - abstracts group or main badge from generator
   def get_config(name, group)
     if group
@@ -136,22 +136,22 @@ class SimpleCov::Formatter::BadgeFormatter
       eval("@@#{name}")
     end
   end
-  
+
   # checks if imagemagick is installed and working
   def check_imagemagick
-    output = `convert`
+    output = `convert -version`
     raise ImageMagickError, "ImageMagick doesn't appear to be installed." unless $?.to_i == 0
   end
-  
+
   # Checks exit status after running a command with backtick
   def check_status(output)
     raise ImageMagickError, "ImageMagick exited with an error. It said:\n #{output}" unless $?.to_i == 0
   end
-  
+
   def output_message(result)
     "Coverage badge generated for #{result.command_name} to #{output_path}."
   end
-  
+
   def output_path
     SimpleCov.coverage_path
   end
@@ -169,7 +169,7 @@ class SimpleCov::Formatter::BadgeFormatter
       @@red
     end
   end
-  
+
   def title_foreground(cov, strength, foreground, use)
     if !foreground or !use
       'white'
@@ -181,7 +181,7 @@ class SimpleCov::Formatter::BadgeFormatter
       @@red
     end
   end
-  
+
   def strength_background(strength, foreground)
     if foreground
       'transparent'
@@ -189,7 +189,7 @@ class SimpleCov::Formatter::BadgeFormatter
       strength_color(strength)
     end
   end
-  
+
   def strength_foreground(strength, foreground)
     unless foreground
       'white'
@@ -197,7 +197,7 @@ class SimpleCov::Formatter::BadgeFormatter
       strength_color(strength)
     end
   end
-  
+
   def coverage_color(covered_percent)
     if covered_percent > 90
       @@green


### PR DESCRIPTION
On OS X `convert` returns 1, but `convert -version` returns 0. If this check passes on GNU+Linux I think you should merge it. Cheers!